### PR TITLE
Fixing deviance between TextLayer and html text.

### DIFF
--- a/ControlPanelLayer.coffee
+++ b/ControlPanelLayer.coffee
@@ -105,6 +105,7 @@ class ControlPanelLayer extends Layer
 		panelRowHeight = 34 * @options.scaleFactor
 		minimumPanelHeight = 2 * panelRowHeight + panelTopMargin + panelBottomMargin
 		panelLabelSize = 16 * @options.scaleFactor
+		panelLabelMargin = 6 * @options.scaleFactor
 		panelTipSize = 12 * @options.scaleFactor
 		panelTipMargin = -8 * @options.scaleFactor
 		radioButtonSize = 20 * @options.scaleFactor
@@ -187,6 +188,7 @@ class ControlPanelLayer extends Layer
 					parent: rowBlock
 					height: panelRowHeight
 					width: labelWidth
+					y: panelLabelMargin
 					backgroundColor: "clear"
 					html: "<p>#{@options.specs[row].label}</p>"
 					style:

--- a/ControlPanelLayer.coffee
+++ b/ControlPanelLayer.coffee
@@ -182,34 +182,35 @@ class ControlPanelLayer extends Layer
 
 				rows.push(rowBlock)
 
-				label = new TextLayer
+				label = new Layer
 					name: _.camelCase(@options.specs[row].label + "Label")
 					parent: rowBlock
-					color: @options.textColor
-					text: @options.specs[row].label
-					fontSize: panelLabelSize
-					fontWeight: 500
-					textAlign: "right"
-					padding:
-						vertical: panelLabelSize/3
 					height: panelRowHeight
 					width: labelWidth
+					backgroundColor: "clear"
+					html: "<p>#{@options.specs[row].label}</p>"
+					style:
+						"font-size": panelLabelSize + "px"
+						"font-weight": "500"
+						"text-align": "right"
+						"color": @options.textColor
 
 				@[label.name] = label
 
 				if tipRequired
-					tip = new TextLayer
+					tip = new Layer
 						name: _.camelCase(@options.specs[row].label + "Tip")
 						parent: rowBlock
 						height: panelRowHeight * 0.4
 						width: labelWidth
 						y: label.maxY + panelTipMargin
-						color: @options.textColor
-						text: @options.specs[row].tip
-						fontSize: panelTipSize
-						fontWeight: 500
-						textAlign: "right"
-						truncate: true
+						backgroundColor: "clear"
+						html: "<p>#{@options.specs[row].tip}</p>"
+						style:
+							"font-size": panelTipSize + "px"
+							"font-weight": "500"
+							"text-align": "right"
+							"color": @options.textColor
 
 					@[tip.name] = tip
 


### PR DESCRIPTION
Recent Framer changes have introduced too many inconsistencies between TextLayer rendering and html text rendering to continue using both side-by-side. TextLayer is preferable but doesn't afford the input features this module requires, so I've switched labels to use html text.

Here's what it looked like before:

![screenshot 2017-07-25 09 21 37](https://user-images.githubusercontent.com/935/28578395-3d647ce0-711f-11e7-8286-933ad33731ae.png)

Here's what it should look like on _most_ device types now:

![image](https://user-images.githubusercontent.com/935/28578465-74e0d8f8-711f-11e7-9d70-3a702a5a42d0.png)

Here's the quick test:

```coffeescript
ControlPanelLayer = require "ControlPanelLayer"

exampleSpecs =
	defaultText:
		label: "Default text"
		value: "hello"
		tip: "Initial text to display."
	animationTime:
		label: "Animation time"
		value: 5
		tip: "How long the animation will run."
	autoplay:
		label: "Should autoplay"
		value: false

myCP = new ControlPanelLayer
	specs: exampleSpecs
```